### PR TITLE
test(router): add `RouterTestingModule` and `provideRouter` to app an…

### DIFF
--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -4,6 +4,8 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import localeFr from '@angular/common/locales/fr';
 import { LOCALE_ID } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { App } from './app';
 
 registerLocaleData(localeFr);
@@ -11,10 +13,11 @@ registerLocaleData(localeFr);
 describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [App],
+      imports: [App, RouterTestingModule],
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),
+        provideRouter([]),
         { provide: LOCALE_ID, useValue: 'fr' }
       ]
     }).compileComponents();

--- a/src/app/core/layout/header/navbar/navbar.spec.ts
+++ b/src/app/core/layout/header/navbar/navbar.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { Navbar } from './navbar';
 
@@ -8,7 +10,10 @@ describe('Navbar', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Navbar],
+      imports: [Navbar, RouterTestingModule],
+      providers: [
+        provideRouter([])
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(Navbar);


### PR DESCRIPTION
…d navbar specs

- Include `RouterTestingModule` in test imports for `App` and `Navbar` to enable routing tests.
- Provide empty routes with `provideRouter` for isolated unit test environments.